### PR TITLE
Out of the box support for Wasm plugin with static rule config

### DIFF
--- a/wasmplugin/prep-Dockerfile-static.sh
+++ b/wasmplugin/prep-Dockerfile-static.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp Dockerfile Dockerfile-static
+sed -i 's/envoy-wasm-modsecurity-dynamic/envoy-wasm-modsecurity/' ./Dockerfile-static
+sed -i 's/\&\& make\s*$/\&\& make envoy-wasm-modsecurity.wasm/' ./Dockerfile-static


### PR DESCRIPTION
See https://github.com/intel/modsecurity-wasm-filter/issues/35
This PR updates the methods in envoy-wasm-modsecurity.cc based on the code in envoy-wasm-modsecurity-dynamic.cc
Also provides a prep-Dockerfile-static.sh that generates a Dockerfile-static file based on Dockerfile.